### PR TITLE
Add ability to replace method name

### DIFF
--- a/IntegrationTests/Sources/ViewController.swift
+++ b/IntegrationTests/Sources/ViewController.swift
@@ -7,5 +7,6 @@ class ViewController: UIViewController {
         super.viewDidLoad()
 
         viewModel.name = "Initial Name"
+        viewModel.foo(input: 1)
     }
 }

--- a/IntegrationTests/Sources/ViewModel.swift
+++ b/IntegrationTests/Sources/ViewModel.swift
@@ -1,3 +1,5 @@
 class ViewModel {
+    typealias Input = Int
+    func foo(input: Input) {}
     var name: String?
 }

--- a/Sources/SwiftRenamer/SwiftRenamer.swift
+++ b/Sources/SwiftRenamer/SwiftRenamer.swift
@@ -55,10 +55,21 @@ public struct SwiftRenamer {
         for entry in entries {
             let occs = usrToOccurrence[entry.usr]!
             for occ in occs {
+                let symbolLength: Int
+
+                if occ.symbol.kind == .instancemethod {
+                    let name = occ.symbol.name
+                    guard let indexOfLastOfName = name.firstIndex(of: "(") else { continue }
+                    symbolLength = name.distance(from: name.startIndex, to: indexOfLastOfName)
+                } else {
+                    symbolLength = occ.symbol.name.count
+                }
+
                 let replacement = Replacement(
                     location: .init(line: occ.location.line, column: occ.location.column),
-                    length: occ.symbol.name.count, newText: entry.newText
+                    length: symbolLength, newText: entry.newText
                 )
+
                 if results[occ.location.path] == nil {
                     results[occ.location.path] = [replacement]
                 } else {


### PR DESCRIPTION
When `occ.symbol.kind = .instancemethod`, `symbol.name` is always something like `method(argument:labels:)` even corresponding source code is declaration or method.

Let's say there is an instance method declaration `func method(argument: Int, labels: String)`. Current implementation of `SwiftRenamer.replacements(where:)` produces garbled string  `func newMethodNamebels: String)` when `condition` returned `newMethodName`  since it assumes length of the original string is "method(argument:labels:)".

This patch changes this behavior and replacer returns `func newMethodName(argument: Int, labels: String)` in above case.
